### PR TITLE
Updated composer.json for symfony/console 7.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "composer/semver": "^3.4",
         "illuminate/container": "^12.14",
         "nette/utils": "^4.0",
-        "symfony/console": "^6.4",
+        "symfony/console": "^7.3",
         "symfony/finder": "^7.2",
         "symfony/process": "^7.2",
         "webmozart/assert": "^1.11"


### PR DESCRIPTION
The composer error below indicates a dependency conflict between nunomaduro/collision and rector/jack packages that require incompatible versions of the symfony/console dependency, so I updated composer.json for symfony/console 7.3 version, that seams to work without problems.

```
Loading composer repositories with package information
Updating dependencies                                 
Your requirements could not be resolved to an installable set of packages.
  Problem 1
    - Root composer.json requires nunomaduro/collision ^8.6 -> satisfiable by nunomaduro/collision[v8.6.0, ..., v8.x-dev].
    - Root composer.json requires rector/jack ^0.2.4 -> satisfiable by rector/jack[0.2.4].
    - nunomaduro/collision[v8.6.0, ..., v8.7.0] require symfony/console ^7.2.1 -> satisfiable by symfony/console[v7.2.1, ..., 7.4.x-dev].
    - nunomaduro/collision v8.8.0 requires symfony/console ^7.2.5 -> satisfiable by symfony/console[v7.2.5, ..., 7.4.x-dev].
    - nunomaduro/collision[v8.8.1, ..., v8.x-dev] require symfony/console ^7.3.0 -> satisfiable by symfony/console[v7.3.0-BETA1, ..., 7.4.x-dev].
    - rector/jack 0.2.4 requires symfony/console ^6.4 -> satisfiable by symfony/console[v6.4.0-BETA1, ..., 6.4.x-dev].
    - You can only install one version of a package, so only one of these can be installed: symfony/console[v2.8.52, 2.8.x-dev, v3.4.0-BETA1, ..., 3.4.x-dev, v4.0.0-BETA1, ..., 4.4.x-dev, v5.0.0-BETA1, ..., 5.4.x-dev, v6.0.0-BETA1, ..., 6.4.x-dev, v7.0.0-BETA1, ..., 7.4.x-dev].
```