### PR TITLE
[ComposerProcessor] Skip change under "suggest" config in composer.json for RaiseToInstalledComposerProcessor

### DIFF
--- a/src/FileSystem/ComposerJsonPackageVersionUpdater.php
+++ b/src/FileSystem/ComposerJsonPackageVersionUpdater.php
@@ -11,12 +11,24 @@ final class ComposerJsonPackageVersionUpdater
     public static function update(string $composerJsonContents, string $packageName, string $newVersion): string
     {
         // replace using regex, to keep original composer.json format
-        return Strings::replace(
+        $allChanges = Strings::replace(
             $composerJsonContents,
             // find
             sprintf('#"%s": "(.*?)"#', $packageName),
             // replace
             sprintf('"%s": "%s"', $packageName, $newVersion)
         );
+
+        $suggestContent = Strings::match($composerJsonContents, '#"suggest"\s*:\s*{[^}]*}#');
+
+        if ($suggestContent !== null) {
+            $allChanges = Strings::replace(
+                $allChanges,
+                '#"suggest"\s*:\s*{[^}]*}#',
+                $suggestContent[0]
+            );
+        }
+
+        return $allChanges;
     }
 }

--- a/tests/ComposerProcessor/RaiseToInstalledComposerProcessor/Fixture/skip-suggest-early-definition.json
+++ b/tests/ComposerProcessor/RaiseToInstalledComposerProcessor/Fixture/skip-suggest-early-definition.json
@@ -1,6 +1,6 @@
 {
     "suggest": {
-      "illuminate/container": "to use container"
+        "illuminate/container": "to use container"
     },
     "require-dev": {
         "illuminate/container": "^9.0"

--- a/tests/ComposerProcessor/RaiseToInstalledComposerProcessor/Fixture/skip-suggest-early-definition.json
+++ b/tests/ComposerProcessor/RaiseToInstalledComposerProcessor/Fixture/skip-suggest-early-definition.json
@@ -1,0 +1,8 @@
+{
+    "suggest": {
+      "illuminate/container": "to use container"
+    },
+    "require-dev": {
+        "illuminate/container": "^9.0"
+    }
+}

--- a/tests/ComposerProcessor/RaiseToInstalledComposerProcessor/Fixture/skip-suggest.json
+++ b/tests/ComposerProcessor/RaiseToInstalledComposerProcessor/Fixture/skip-suggest.json
@@ -3,6 +3,6 @@
         "illuminate/container": "^9.0"
     },
     "suggest": {
-      "illuminate/container": "to use container"
+        "illuminate/container": "to use container"
     }
 }

--- a/tests/ComposerProcessor/RaiseToInstalledComposerProcessor/Fixture/skip-suggest.json
+++ b/tests/ComposerProcessor/RaiseToInstalledComposerProcessor/Fixture/skip-suggest.json
@@ -1,0 +1,8 @@
+{
+    "require-dev": {
+        "illuminate/container": "^9.0"
+    },
+    "suggest": {
+      "illuminate/container": "to use container"
+    }
+}

--- a/tests/ComposerProcessor/RaiseToInstalledComposerProcessor/RaiseToInstalledComposerProcessorTest.php
+++ b/tests/ComposerProcessor/RaiseToInstalledComposerProcessor/RaiseToInstalledComposerProcessorTest.php
@@ -49,6 +49,34 @@ final class RaiseToInstalledComposerProcessorTest extends AbstractTestCase
         $this->assertEmpty($changedPackageVersionsResult->getChangedPackageVersions());
     }
 
+    public function testSkipSuggestChange(): void
+    {
+        $composerJsonContents = FileSystem::read(__DIR__ . '/Fixture/skip-suggest.json');
+
+        $changedPackageVersionsResult = $this->raiseToInstalledComposerProcessor->process($composerJsonContents);
+
+        $changedPackageVersion = $changedPackageVersionsResult->getChangedPackageVersions()[0];
+
+        $this->assertSame('illuminate/container', $changedPackageVersion->getPackageName());
+        $this->assertSame('^9.0', $changedPackageVersion->getOldVersion());
+        $this->assertSame('^12.19', $changedPackageVersion->getNewVersion());
+
+        $this->assertSame(<<<'JSON'
+{
+    "require-dev": {
+        "illuminate/container": "^12.19"
+    },
+    "suggest": {
+      "illuminate/container": "to use container"
+    }
+}
+
+JSON
+        ,
+        $changedPackageVersionsResult->getComposerJsonContents()
+        );
+    }
+
     public function testSinglePiped(): void
     {
         $composerJsonContents = FileSystem::read(__DIR__ . '/Fixture/single-piped.json');

--- a/tests/ComposerProcessor/RaiseToInstalledComposerProcessor/RaiseToInstalledComposerProcessorTest.php
+++ b/tests/ComposerProcessor/RaiseToInstalledComposerProcessor/RaiseToInstalledComposerProcessorTest.php
@@ -60,7 +60,7 @@ final class RaiseToInstalledComposerProcessorTest extends AbstractTestCase
                     "illuminate/container": "^12.19"
                 },
                 "suggest": {
-                "illuminate/container": "to use container"
+                    "illuminate/container": "to use container"
                 }
             }
 
@@ -72,7 +72,7 @@ final class RaiseToInstalledComposerProcessorTest extends AbstractTestCase
             <<<'JSON'
             {
                 "suggest": {
-                "illuminate/container": "to use container"
+                    "illuminate/container": "to use container"
                 },
                 "require-dev": {
                     "illuminate/container": "^12.19"

--- a/tests/ComposerProcessor/RaiseToInstalledComposerProcessor/RaiseToInstalledComposerProcessorTest.php
+++ b/tests/ComposerProcessor/RaiseToInstalledComposerProcessor/RaiseToInstalledComposerProcessorTest.php
@@ -50,6 +50,9 @@ final class RaiseToInstalledComposerProcessorTest extends AbstractTestCase
         $this->assertEmpty($changedPackageVersionsResult->getChangedPackageVersions());
     }
 
+    /**
+     * @return iterable<array{string, string}>
+     */
     public static function provideSkipSuggestChangeFiles(): iterable
     {
         yield [


### PR DESCRIPTION
Fixes https://github.com/rectorphp/jack/issues/26

To resolve this diff which on suggest should be no changed:

```diff
There was 1 failure:

1) Rector\Jack\Tests\ComposerProcessor\RaiseToInstalledComposerProcessor\RaiseToInstalledComposerProcessorTest::testSkipSuggestChange
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
         "illuminate/container": "^12.19"
     },
     "suggest": {
-      "illuminate/container": "to use container"
+      "illuminate/container": "^12.19"
     }
 }
```