### PR TITLE
[ComposerProcessor] Skip change under "replace", "conflict", "provide" config in composer.json for RaiseToInstalledComposerProcessor

### DIFF
--- a/src/FileSystem/ComposerJsonPackageVersionUpdater.php
+++ b/src/FileSystem/ComposerJsonPackageVersionUpdater.php
@@ -19,14 +19,15 @@ final class ComposerJsonPackageVersionUpdater
             sprintf('"%s": "%s"', $packageName, $newVersion)
         );
 
-        $suggestContent = Strings::match($composerJsonContents, '#"suggest"\s*:\s*{[^}]*}#');
+        $skippedKeys = ['suggest', 'replace', 'provide', 'conflict'];
 
-        if ($suggestContent !== null) {
-            $allChanges = Strings::replace(
-                $allChanges,
-                '#"suggest"\s*:\s*{[^}]*}#',
-                $suggestContent[0]
-            );
+        foreach ($skippedKeys as $skippedKey) {
+            $regexKeyContent = sprintf('#"%s"\s*:\s*{[^}]*}#', $skippedKey);
+            $skippedContent = Strings::match($composerJsonContents, $regexKeyContent);
+
+            if ($skippedContent !== null) {
+                $allChanges = Strings::replace($allChanges, $regexKeyContent, $skippedContent[0]);
+            }
         }
 
         return $allChanges;

--- a/tests/ComposerProcessor/RaiseToInstalledComposerProcessor/Fixture/skip-conflict.json
+++ b/tests/ComposerProcessor/RaiseToInstalledComposerProcessor/Fixture/skip-conflict.json
@@ -1,0 +1,8 @@
+{
+    "require-dev": {
+        "illuminate/container": "^9.0"
+    },
+    "conflict": {
+        "illuminate/container": "<9.0"
+    }
+}

--- a/tests/ComposerProcessor/RaiseToInstalledComposerProcessor/RaiseToInstalledComposerProcessorTest.php
+++ b/tests/ComposerProcessor/RaiseToInstalledComposerProcessor/RaiseToInstalledComposerProcessorTest.php
@@ -102,6 +102,35 @@ final class RaiseToInstalledComposerProcessorTest extends AbstractTestCase
         $this->assertSame($changedFileContent, $changedPackageVersionsResult->getComposerJsonContents());
     }
 
+    public function testSkipConflictChange(): void
+    {
+        $composerJsonContents = FileSystem::read(__DIR__ . '/Fixture/skip-conflict.json');
+
+        $changedPackageVersionsResult = $this->raiseToInstalledComposerProcessor->process($composerJsonContents);
+
+        $changedPackageVersion = $changedPackageVersionsResult->getChangedPackageVersions()[0];
+
+        $this->assertSame('illuminate/container', $changedPackageVersion->getPackageName());
+        $this->assertSame('^9.0', $changedPackageVersion->getOldVersion());
+        $this->assertSame('^12.19', $changedPackageVersion->getNewVersion());
+
+        $this->assertSame(
+            <<<'JSON'
+            {
+                "require-dev": {
+                    "illuminate/container": "^12.19"
+                },
+                "conflict": {
+                    "illuminate/container": "<9.0"
+                }
+            }
+
+            JSON
+            ,
+            $changedPackageVersionsResult->getComposerJsonContents()
+        );
+    }
+
     public function testSinglePiped(): void
     {
         $composerJsonContents = FileSystem::read(__DIR__ . '/Fixture/single-piped.json');


### PR DESCRIPTION
Continue of PR:

- https://github.com/rectorphp/jack/pull/27

@94noni this skip change under replace, conflict, and provide as well.