### PR TITLE
[Console] Fix symfony/console diff broken on windows on symfony/console 6.4.24

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "composer/semver": "^3.4",
         "illuminate/container": "^12.14",
         "nette/utils": "^4.0",
-        "symfony/console": "^6.4",
+        "symfony/console": "^6.4.24",
         "symfony/finder": "^7.2",
         "symfony/process": "^7.2",
         "webmozart/assert": "^1.11"
@@ -39,8 +39,7 @@
     },
     "replace": {
         "symfony/polyfill-ctype": "*",
-        "symfony/polyfill-intl-normalizer": "*",
-        "symfony/polyfill-mbstring": "*"
+        "symfony/polyfill-intl-normalizer": "*"
     },
     "config": {
         "sort-packages": true,
@@ -55,12 +54,5 @@
         "fix-cs": "vendor/bin/ecs check --fix --ansi",
         "phpstan": "vendor/bin/phpstan analyse --ansi",
         "rector": "vendor/bin/rector process --ansi"
-    },
-    "extra": {
-        "patches": {
-            "symfony/console": [
-                "patches/symfony-console-helper-helper-php.patch"
-            ]
-        }
     }
 }

--- a/tests/ComposerProcessor/RaiseToInstalledComposerProcessor/RaiseToInstalledComposerProcessorTest.php
+++ b/tests/ComposerProcessor/RaiseToInstalledComposerProcessor/RaiseToInstalledComposerProcessorTest.php
@@ -39,7 +39,7 @@ final class RaiseToInstalledComposerProcessorTest extends AbstractTestCase
         $this->assertSame('^9.0', $changedPackageVersion->getOldVersion());
 
         // note: this might change in near future; improve to dynamic soon
-        $this->assertStringStartsWith('^12.1', $changedPackageVersion->getNewVersion());
+        $this->assertStringStartsWith('^12.2', $changedPackageVersion->getNewVersion());
     }
 
     public function testSkipDev(): void
@@ -60,7 +60,7 @@ final class RaiseToInstalledComposerProcessorTest extends AbstractTestCase
             <<<'JSON'
             {
                 "require-dev": {
-                    "illuminate/container": "^12.19"
+                    "illuminate/container": "^12.24"
                 },
                 "suggest": {
                     "illuminate/container": "to use container"
@@ -78,7 +78,7 @@ final class RaiseToInstalledComposerProcessorTest extends AbstractTestCase
                     "illuminate/container": "to use container"
                 },
                 "require-dev": {
-                    "illuminate/container": "^12.19"
+                    "illuminate/container": "^12.24"
                 }
             }
 
@@ -97,7 +97,7 @@ final class RaiseToInstalledComposerProcessorTest extends AbstractTestCase
 
         $this->assertSame('illuminate/container', $changedPackageVersion->getPackageName());
         $this->assertSame('^9.0', $changedPackageVersion->getOldVersion());
-        $this->assertSame('^12.19', $changedPackageVersion->getNewVersion());
+        $this->assertSame('^12.24', $changedPackageVersion->getNewVersion());
 
         $this->assertSame($changedFileContent, $changedPackageVersionsResult->getComposerJsonContents());
     }
@@ -112,13 +112,13 @@ final class RaiseToInstalledComposerProcessorTest extends AbstractTestCase
 
         $this->assertSame('illuminate/container', $changedPackageVersion->getPackageName());
         $this->assertSame('^9.0', $changedPackageVersion->getOldVersion());
-        $this->assertSame('^12.19', $changedPackageVersion->getNewVersion());
+        $this->assertSame('^12.24', $changedPackageVersion->getNewVersion());
 
         $this->assertSame(
             <<<'JSON'
             {
                 "require-dev": {
-                    "illuminate/container": "^12.19"
+                    "illuminate/container": "^12.24"
                 },
                 "conflict": {
                     "illuminate/container": "<9.0"
@@ -141,7 +141,7 @@ final class RaiseToInstalledComposerProcessorTest extends AbstractTestCase
 
         $this->assertSame('illuminate/container', $changedPackageVersion->getPackageName());
         $this->assertSame('^12.14 | 13.0', $changedPackageVersion->getOldVersion());
-        $this->assertSame('^12.19', $changedPackageVersion->getNewVersion());
+        $this->assertSame('^12.24', $changedPackageVersion->getNewVersion());
     }
 
     public function testDoublePiped(): void
@@ -154,6 +154,6 @@ final class RaiseToInstalledComposerProcessorTest extends AbstractTestCase
 
         $this->assertSame('illuminate/container', $changedPackageVersion->getPackageName());
         $this->assertSame('^12.14 | 13.0', $changedPackageVersion->getOldVersion());
-        $this->assertSame('^12.19', $changedPackageVersion->getNewVersion());
+        $this->assertSame('^12.24', $changedPackageVersion->getNewVersion());
     }
 }


### PR DESCRIPTION
similar with rector side:

- https://github.com/rectorphp/rector-src/pull/7148

Since symfony/console 6.4.24, the vendor/patch for symfony/console no longer valid. Remove the vendor patch resolve it.

The reason it now working is because `symfony/string` is now included in vendor scoped, see related PRs:

- https://github.com/rectorphp/rector-src/pull/7102
- https://github.com/easy-coding-standard/easy-coding-standard/pull/284

that previously on replace, but now required may due to latest `myclabs/deep-copy:1.13.4`

and in `symfony/console` 6.4.24, **the helper used everywhere.**
