### PR TITLE
Prepare push repository logic to anywherephp/jack

### DIFF
--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -34,7 +34,7 @@ jobs:
 
                     -
                         name: "Commented Code"
-                        run: vendor/bin/swiss-knife check-commented-code src tests --ansi
+                        run: vendor/bin/swiss-knife check-commented-code src tests
 
                     -
                         name: 'Jack: Open Versions'

--- a/.github/workflows/downgraded_release.yaml
+++ b/.github/workflows/downgraded_release.yaml
@@ -2,9 +2,9 @@ name: Downgraded Release
 
 on:
     push:
+        branches:
+            - main
         tags:
-            # avoid infinite looping, skip tags that ends with ".74"
-            # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-and-excluding-branches
             - '*'
 
 jobs:
@@ -12,9 +12,9 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            -   uses: "actions/checkout@v3"
+            -   uses: "actions/checkout@v5"
                 with:
-                    token: ${{ secrets.WORKFLOWS_TOKEN }}
+                    token: ${{ secrets.WORKFLOWS_TOKEN || github.token }}
 
             -
                 uses: "shivammathur/setup-php@v2"
@@ -32,35 +32,65 @@ jobs:
             -   run: mkdir rector-local
             -   run: composer require rector/rector --working-dir rector-local --ansi
 
-            # downgrade to PHP 7.4
+            # downgrade to PHP 7.2
             -   run: rector-local/vendor/bin/rector process bin src vendor --config build/rector-downgrade-php.php --ansi
 
             # clear the dev files
-            -   run: rm -rf tests ecs.php phpstan.neon phpunit.xml .gitignore .editorconfig
+            -   run: rm -rf tests ecs.php phpstan.neon phpunit.xml .gitignore .editorconfig composer.lock composer-dependency-analyser.php
 
             # prefix and scope
             -   run: sh prefix-code.sh
 
-            # copy PHP 7.4 composer + workflows
+            # remove the original .github, to fully override it with the target repository one below
+            -   run: rm -rf .github
+
+            # copy PHP 7.2 composer + workflows
             -   run: cp -r build/target-repository/. .
 
-            # clear the dev files
+            # clear the build files
             -   run: rm -rf build prefix-code.sh full-tool-build.sh scoper.php rector.php php-scoper.phar rector-local
+
+            # clone the remote repository, so we can commit on top of its history and push without --force
+            # inspired by https://github.com/easy-coding-standard/ecs-src/blob/main/.github/workflows/buid_release.yaml
+            -
+                uses: "actions/checkout@v5"
+                with:
+                    repository: anywherephp/jack
+                    path: remote-repository
+                    token: ${{ secrets.WORKFLOWS_TOKEN }}
+
+            # remove remote files, to avoid piling up dead code in remote repository
+            # the remote .gitignore must go too, as it ignores the /vendor that is shipped in this scoped build
+            -   run: rm -rf remote-repository/bin remote-repository/src remote-repository/vendor remote-repository/docs remote-repository/.github remote-repository/.gitignore
+
+            # copy the downgraded code to the remote repository
+            -   run: rsync -a --exclude .git --exclude remote-repository ./ remote-repository/
 
             # setup git user
             -
+                working-directory: remote-repository
                 run: |
-                    git config user.email "action@github.com"
-                    git config user.name "GitHub Action"
-            # publish to the same repository with a new tag
-            # see https://tomasvotruba.com/blog/how-to-release-php-81-and-72-package-in-the-same-repository/
-            -
-                name: "Tag Downgraded Code"
-                run: |
-                    # separate a "git add" to add untracked (new) files too
-                    git add --all
-                    git commit -m "release PHP 7.2 downgraded"
+                    git config user.email "tomas@getrector.org"
+                    git config user.name "rector-bot"
 
-                    # force push tag, so there is only 1 version
-                    git tag "${GITHUB_REF#refs/tags/}" --force
-                    git push origin "${GITHUB_REF#refs/tags/}" --force
+            # publish to remote repository without tag
+            -
+                name: "Push Downgraded Code - branch"
+                working-directory: remote-repository
+                if: "!startsWith(github.ref, 'refs/tags/')"
+                run: |
+                    git add --all
+                    git commit -m "Updated Jack to commit ${{ github.event.after }}"
+                    git push --quiet origin main
+
+            # publish to remote repository with tag
+            -
+                name: "Push Downgraded Code - tag"
+                working-directory: remote-repository
+                if: "startsWith(github.ref, 'refs/tags/')"
+                run: |
+                    git add --all
+                    git commit --allow-empty -m "Jack ${GITHUB_REF#refs/tags/}"
+                    git push --quiet origin main
+                    git tag "${GITHUB_REF#refs/tags/}" -m "${GITHUB_REF#refs/tags/}"
+                    git push --quiet origin "${GITHUB_REF#refs/tags/}"

--- a/build/target-repository/.github/FUNDING.yml
+++ b/build/target-repository/.github/FUNDING.yml
@@ -1,3 +1,0 @@
-# These are supported funding model platforms
-github: tomasvotruba
-custom: https://www.paypal.me/rectorphp

--- a/build/target-repository/.github/workflows/auto_closer.yaml
+++ b/build/target-repository/.github/workflows/auto_closer.yaml
@@ -1,0 +1,23 @@
+name: Auto Closer PR
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        # Optional. Post a issue comment just before closing a pull request.
+        comment: |
+          Hi, thank you for your contribution.
+
+          Unfortunately, this repository is read-only. It's a build of the main repository.
+
+          We'd like to kindly ask you to move the contribution there - https://github.com/rectorphp/jack.
+
+          We'll check it, review it and give you feed back right way.
+
+          Thank you.

--- a/build/target-repository/README.md
+++ b/build/target-repository/README.md
@@ -1,0 +1,3 @@
+# Jack - Anywhere version
+
+See original repository for more details: https://github.com/rectorphp/jack

--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -1,7 +1,7 @@
 {
-    "name": "rector/jack",
+    "name": "anywherephp/jack",
     "description": "Swiss knife in pocket of every upgrade architect",
-    "license": "MIT",
+    "license": "proprietary",
     "require": {
         "php": ">=7.2"
     },


### PR DESCRIPTION
Same change as rectorphp/type-perfect#75, mirroring TomasVotruba/type-coverage@6474f96d5ec803b23eb22cb606feb27f83ed0c8b.

The `Downgraded Release` workflow now builds the PHP 7.2 downgraded + scoped code and pushes it to https://github.com/anywherephp/jack (already seeded with a `main` branch), instead of force-pushing downgraded tags back into this repository:

- trigger on `main` pushes (updates remote `main`) and on tags (pushes a tag to the remote repository)
- the build mechanics are kept as-is: `composer update --no-dev`, rector-local downgrade of `bin src vendor`, `prefix-code.sh` scoping
- `build/target-repository/composer.json` renamed to `anywherephp/jack` + `proprietary` license
- added `README.md` and `auto_closer.yaml` pointing back here, removed `FUNDING.yml`

Jack-specific details:

- the remote `.gitignore` is removed before committing, because it ignores `/vendor` — and this scoped build **ships** its vendor
- kept `bare_run.yaml` in the target repository — it runs `bin/jack` from checkout on PHP 7.2–8.2, so it smoke-tests every pushed build (unlike type-perfect's `standalone_install.yaml`, it does not depend on Packagist)
- also stops shipping `composer.lock` and `composer-dependency-analyser.php` in the build

⚠️ Notes:
- this **replaces** the self-tagging downgraded release of `rector/jack`
- requires the `WORKFLOWS_TOKEN` secret (already used by the old workflow) to have push access to the `anywherephp` org