### PR TITLE
bare_run: use --help instead of non-existent list command

### DIFF
--- a/build/target-repository/.github/workflows/bare_run.yaml
+++ b/build/target-repository/.github/workflows/bare_run.yaml
@@ -20,4 +20,4 @@ jobs:
                     php-version: ${{ matrix.php_version }}
                     coverage: none
 
-            -   run: php bin/jack list --ansi
+            -   run: php bin/jack --help


### PR DESCRIPTION
The `bare_run.yaml` shipped to anywherephp/jack runs `php bin/jack list --ansi`, but the entropy console has no `list` command (and no `--ansi` option) — so the smoke test fails on every build push: https://github.com/anywherephp/jack/actions/runs/27101288389/job/79982334454

`php bin/jack --help` prints all commands and exits 0 (verified locally on the scoped build), so it serves the same smoke-test purpose: the downgraded code boots on PHP 7.2–8.2.