### PR TITLE
Add list command to print available commands

### DIFF
--- a/build/target-repository/.github/workflows/bare_run.yaml
+++ b/build/target-repository/.github/workflows/bare_run.yaml
@@ -20,4 +20,5 @@ jobs:
                     php-version: ${{ matrix.php_version }}
                     coverage: none
 
-            -   run: php bin/jack --help
+            # no --ansi here, the entropy console does not support it
+            -   run: php bin/jack list

--- a/src/Command/BreakPointCommand.php
+++ b/src/Command/BreakPointCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Jack\Command;
 
+use DateTimeImmutable;
 use Entropy\Console\Contract\CommandInterface;
 use Entropy\Console\Enum\ExitCode;
 use Entropy\Console\Output\OutputPrinter;
@@ -41,7 +42,7 @@ final readonly class BreakPointCommand implements CommandInterface
         }
 
         $composerJsonFilePath = getcwd() . '/composer.json';
-        $now = new \DateTimeImmutable();
+        $now = new DateTimeImmutable();
         $outdatedComposer = $this->outdatedComposerFactory->createOutdatedComposer(
             array_filter(
                 $responseJson[ComposerKey::INSTALLED_KEY],
@@ -56,12 +57,8 @@ final readonly class BreakPointCommand implements CommandInterface
                         return true;
                     }
 
-                    $pageAgeInDays = (new \DateTimeImmutable($package['latest-release-date']))->diff($now)->days;
-                    if ($pageAgeInDays < $minDays) {
-                        return false;
-                    }
-
-                    return true;
+                    $pageAgeInDays = new DateTimeImmutable($package['latest-release-date'])->diff($now)->days;
+                    return $pageAgeInDays >= $minDays;
                 }
             ),
             $composerJsonFilePath

--- a/src/Command/ListCommand.php
+++ b/src/Command/ListCommand.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Jack\Command;
+
+use Entropy\Console\Contract\CommandInterface;
+use Entropy\Console\Enum\ExitCode;
+use Entropy\Console\Output\HelpPrinter;
+use Entropy\Container\Container;
+
+final readonly class ListCommand implements CommandInterface
+{
+    public function __construct(
+        private Container $container,
+    ) {
+    }
+
+    public function run(): int
+    {
+        // resolved lazily to avoid circular dependency: ListCommand → HelpPrinter → CommandRegistry → ListCommand
+        $helpPrinter = $this->container->make(HelpPrinter::class);
+        $helpPrinter->print();
+
+        return ExitCode::SUCCESS;
+    }
+
+    public function getName(): string
+    {
+        return 'list';
+    }
+
+    public function getDescription(): string
+    {
+        return 'List available commands';
+    }
+}

--- a/src/DependencyInjection/ContainerFactory.php
+++ b/src/DependencyInjection/ContainerFactory.php
@@ -5,12 +5,20 @@ declare(strict_types=1);
 namespace Rector\Jack\DependencyInjection;
 
 use Entropy\Container\Container;
+use Rector\Jack\Command\ListCommand;
 
 final class ContainerFactory
 {
     public function create(): Container
     {
         $container = new Container();
+
+        // register with container itself, so the help printer can be resolved lazily without circular dependency
+        $container->service(
+            ListCommand::class,
+            static fn (Container $container): ListCommand => new ListCommand($container)
+        );
+
         $container->autodiscover(__DIR__ . '/../../src');
 
         return $container;

--- a/tests/Command/ListCommand/ListCommandTest.php
+++ b/tests/Command/ListCommand/ListCommandTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Jack\Tests\Command\ListCommand;
+
+use Entropy\Console\Enum\ExitCode;
+use Rector\Jack\Command\ListCommand;
+use Rector\Jack\Tests\AbstractTestCase;
+
+final class ListCommandTest extends AbstractTestCase
+{
+    private ListCommand $listCommand;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->listCommand = $this->make(ListCommand::class);
+    }
+
+    public function test(): void
+    {
+        $this->assertSame('list', $this->listCommand->getName());
+
+        // output is silenced during unit tests, see OutputPrinter::isSilent
+        $exitCode = $this->listCommand->run();
+        $this->assertSame(ExitCode::SUCCESS, $exitCode);
+    }
+}


### PR DESCRIPTION
Restores the previous CLI behavior: `bin/jack list` works again (it was the smoke-test command in the anywherephp build before #39, but never actually existed in the entropy console).

- `ListCommand` prints the same overview as `--help` and exits 0
- registered explicitly in `ContainerFactory` with lazy `HelpPrinter` resolution, to avoid the circular dependency ListCommand → HelpPrinter → CommandRegistry → ListCommand
- covered by `ListCommandTest` (exit code + name; output assertions are not possible since `OutputPrinter` is silent under PHPUnit by design)
- `build/target-repository/bare_run.yaml` switched back from `--help` to `php bin/jack list`, so the anywherephp/jack smoke test exercises the command again

Also includes a small Rector auto-fix in `BreakPointCommand` (`composer rector` output: DateTimeImmutable import + simplified return).

```
$ php bin/jack list
Commands:
  list                   List available commands
  open-versions          Open composer.json version constraints to the very near next version
  breakpoint             Let your CI tell you, if there are too many major-version outdated packages
  raise-to-installed     Raise your version in "composer.json" to installed one to get the latest version available in any composer update
```

ECS ✅ Rector ✅ PHPStan ✅ PHPUnit ✅ (15 tests)